### PR TITLE
#29 認可処理機能

### DIFF
--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -32,6 +32,7 @@ header {
   position: fixed;
   top: 0;
   width: 100%;
+  height: 10%;
 }
 
 header h1 {

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -1,12 +1,10 @@
 class ProductsController < ApplicationController
   def index
-    @user = User.find(params[:id])
     @products = Product.order('created_at ASC').page(params[:page]).per(15)
     @categories = Category.all
   end
 
   def show
-    @user = User.find(params[:id])
     @product = Product.find_by(id: params[:id])
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,9 +1,22 @@
 class UsersController < ApplicationController
+  before_action :logged_in_user, only: [:show, :edit]
+  before_action :correct_user, only: [:show, :edit]
+
   def show
     @user = User.find(params[:id])
   end
   def edit
     @user = User.find(params[:id])
   end
+
+  private
+
+    def correct_user
+      user = User.find(params[:id])
+      unless user == current_user
+        flash[:danger] = "他人の情報にアクセスすることはできません。"
+        redirect_to root_url
+      end
+    end
 
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,6 +1,6 @@
 class UsersController < ApplicationController
-  before_action :logged_in_user, only: [:show, :edit]
-  before_action :correct_user, only: [:show, :edit]
+  before_action :logged_in_user, only: %i(show edit)
+  before_action :correct_user, only: %i(show edit)
 
   def show
     @user = User.find(params[:id])

--- a/app/helpers/sessions_helper.rb
+++ b/app/helpers/sessions_helper.rb
@@ -18,4 +18,11 @@ module SessionsHelper
     end
   end
 
+  def logged_in_user
+    unless logged_in?
+      flash[:danger] = "ログインしてください。"
+      redirect_to login_path
+    end
+  end
+
 end

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -4,17 +4,17 @@
     <nav class="navbar navbar-expand-lg navbar-light">
       <div class="container-fluid">
         <div class="navbar-nav me-auto">
-          <h1><a class="nav-link navbar-brand" href="#">探求学園Rails専攻</a></h1>
+          <h1><%= link_to "探求学園Rails専攻", root_path ,class:"nav-link navbar-brand"%></h1>
         </div>
         <div>
           <ul>
-            <p><%= "#{@user.last_name} #{@user.first_name}さん"%></p>
+            <p><%= "#{@current_user.last_name} #{@current_user.first_name}さん"%></p>
           </ul>
           <ul class="navbar-nav">
-            <a class="nav-link text-dark" href="#">商品検索</a>
+            <%= link_to "商品検索", products_path ,class:"nav-link text-dark"%>
             <a class="nav-link text-dark" href="#">カート</a>
             <a class="nav-link text-dark" href="#">注文履歴</a>
-            <a class="nav-link text-dark" href="#">ユーザ情報</a>
+            <%= link_to "ユーザ情報", user_path(@current_user) ,class:"nav-link text-dark"%>
             <%= link_to "ログアウト", logout_path , method: :delete ,class:"nav-link text-dark"%>
           </ul>
         </div>
@@ -26,7 +26,7 @@
     <nav class="navbar navbar-expand-lg navbar-light">
       <div class="container-fluid">
         <div class="navbar-nav mr-auto">
-          <h1><a class="nav-link navbar-brand" href="#">探求学園Rails専攻</a></h1>
+          <h1><%= link_to "探求学園Rails専攻", root_path ,class:"nav-link navbar-brand"%></h1>
         </div>
         <div>
           <ul>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,8 +1,8 @@
 Rails.application.routes.draw do
-  get 'static_pages/home'
-  get '/login', to: 'sessions#new'
-  post   '/login',  to: 'sessions#create'
-  delete '/logout', to: 'sessions#destroy'
+  root      'static_pages#home'
+  get       '/login',  to: 'sessions#new'
+  post      '/login',  to: 'sessions#create'
+  delete    '/logout', to: 'sessions#destroy'
   resources :products
   resources :users
   resources :orders


### PR DESCRIPTION
## このプルリクエストで何をしたのか
- 認可処理機能の実装
- root_urlを利用するため、
　route.rb内 `get 'static_pages/home' →` root  `    'static_pages#home' `に変更
- ログイン時のheaderの高さ調整（`height:10%;`、flashメッセージが被るため）
- header内のリンクの実装
- header内 @user → @current_user で置き換え、product_controllerの@userの定義を削除

## 対象issue
- https://github.com/quest-academia/qa-rails-ec-training-lily/issues/29

## 重点的に見てほしいところ(不安なところ)
なし

## 実装できなくて後回しにしたところ
なし

## チェックリスト
- [x] 未ログイン時、/users/id、/users/id/edit にアクセスできず、「ログインしてください。」と表示され、
ログイン画面に戻ることを確認
- [x] ログイン時、別ユーザーの/users/id、/users/id/edit にアクセスできず、「他人の情報にアクセスすることはできません。」と表示され、
トップページに遷移することを確認
- [x] ログイン時に商品一覧ページに遷移した際に、エラーが発生せずユーザー名が正常に表示されることを確認
- [x] header内の下記リンクが正常に動作することを確認
- 探求学園Rails専攻　→　トップ画面（ログイン時・未ログイン時）
- 商品検索　→ 商品検索画面（ログイン時のみ）
- ユーザ情報　→ ユーザ情報画面（ログイン時のみ）

## その他参考情報
- Railsチュートリアル　第１０章　認可　https://railstutorial.jp/chapters/updating_and_deleting_users?version=6.0#sec-authorization
- Rubyで%記法　https://qiita.com/mogulla3/items/46bb876391be07921743
