### PR TITLE
#37 注文履歴

### DIFF
--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -1,5 +1,23 @@
 class OrdersController < ApplicationController
+  before_action :logged_in_user, only: %i[show index]
+  before_action :correct_user, only: %i[show]
+
   def show
     @order = Order.find_by(id: params[:id])
   end
+
+  def index
+    @orders = Order.order("order_date DESC").page(params[:page]).per(15)
+  end
+
+  private
+
+    def correct_user
+      user = User.find_by(id: Order.find_by(id: params[:id]).user_id)
+      unless user == current_user
+        flash[:danger] = "他人の情報にアクセスすることはできません。"
+        redirect_to orders_path
+      end
+    end
+
 end

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -19,5 +19,4 @@ class OrdersController < ApplicationController
         redirect_to orders_path
       end
     end
-
 end

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -3,11 +3,11 @@ class OrdersController < ApplicationController
   before_action :correct_user, only: %i[show]
 
   def show
-    @order = Order.find_by(id: params[:id])
+    @order = current_user.orders.find_by(id: params[:id])
   end
 
   def index
-    @orders = Order.order("order_date DESC").page(params[:page]).per(15)
+    @orders = current_user.orders.order("order_date DESC").page(params[:page]).per(15)
   end
 
   private

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -8,5 +8,4 @@ class OrdersController < ApplicationController
   def index
     @orders = current_user.orders.order("order_date DESC").page(params[:page]).per(15)
   end
-
 end

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -1,6 +1,5 @@
 class OrdersController < ApplicationController
   before_action :logged_in_user, only: %i[show index]
-  before_action :correct_user, only: %i[show]
 
   def show
     @order = current_user.orders.find_by(id: params[:id])
@@ -10,13 +9,4 @@ class OrdersController < ApplicationController
     @orders = current_user.orders.order("order_date DESC").page(params[:page]).per(15)
   end
 
-  private
-
-    def correct_user
-      user = User.find_by(id: Order.find_by(id: params[:id]).user_id)
-      unless user == current_user
-        flash[:danger] = "他人の情報にアクセスすることはできません。"
-        redirect_to orders_path
-      end
-    end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,5 +1,6 @@
 class User < ApplicationRecord
   belongs_to :user_classification
+  has_many :orders, dependent: :destroy
   before_save { self.email = email.downcase }
   has_secure_password
 

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -13,7 +13,7 @@
           <ul class="navbar-nav">
             <%= link_to "商品検索", products_path ,class:"nav-link text-dark"%>
             <a class="nav-link text-dark" href="#">カート</a>
-            <a class="nav-link text-dark" href="#">注文履歴</a>
+            <%= link_to "注文履歴", orders_path ,class:"nav-link text-dark"%>
             <%= link_to "ユーザ情報", user_path(@current_user) ,class:"nav-link text-dark"%>
             <%= link_to "ログアウト", logout_path , method: :delete ,class:"nav-link text-dark"%>
           </ul>

--- a/app/views/orders/index.html.erb
+++ b/app/views/orders/index.html.erb
@@ -1,0 +1,75 @@
+<% if @orders.present? %>
+  <main>
+    <div class="container my-4 mt-5">
+      <a href="#" class="btn btn-secondary py-0">直近3ヶ月の注文を表示</a>
+    </div>
+
+    <div class="container">
+      <hr style="width:90%; opacity:0.9;">
+      <table class="table">
+        <thead class="table h4">
+          <tr>
+            <th class="text-start" width="5%">
+              No
+            </th>
+            <th class="text-start" width="20%">
+              注文番号
+            </th>
+            <th class="text-start" width="40%">
+              お届け先
+            </th>
+            <th class="text-start" width="25%">
+              備考
+            </th>
+            <th class="text-start border-0" width="20%"></th>
+          </tr>
+        </thead>
+        <tbody class="h6 font-weight-normal">
+          <% @orders.each.with_index(1) do |order,i| %>
+            <tr>
+              <th class="font-weight-normal" scope="row">
+                <%= "#{@orders.offset_value + i}" %>
+              </th>
+              <td class="text-left">
+                <%= order.order_number %>
+              </td>
+              <td class="text-left">
+                <%= "〒#{current_user.zipcode[0..2]}-#{current_user.zipcode[3..6]}" %><br />
+                <%= "#{current_user.prefecture}#{current_user.municipality}#{current_user.address}#{current_user.apartments}" %><br />
+                <%= "#{@current_user.last_name} #{@current_user.first_name}さん"%>
+              </th>
+              <td class="text-left">
+                <%= "注文日時：#{order.order_date.strftime("%Y/%m/%d")}" %><br />
+                <% if order.has_prepared_shipment_status? %>
+                  準備中
+                <% else %>
+                  発送済
+                <% end %>
+              </td>
+              <td class="border-0 align-middle">
+                <%= link_to "詳細", order_path(order) , class:"btn btn-primary btn-sm"%>
+              </td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    </div>
+
+    <div class="container">
+      <nav aria-label="...">
+        <ul class="pagination justify-content-center">
+          <%= paginate @orders %>
+        </ul>
+      </nav>
+    </div>
+
+  </main>
+<% else %>
+
+  <main>
+    <div class="blockquote mt-5 text-center">
+      <h1 style="font-weight: bolder">注文履歴が存在しません</h1>
+    </div>
+  </main>
+
+<% end %>

--- a/app/views/orders/show.html.erb
+++ b/app/views/orders/show.html.erb
@@ -1,105 +1,68 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
-<html lang="ja">
-
-<head>
-  <meta charset="utf-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
-  <title>注文詳細</title>
-</head>
-  <body>
-    <header>
-      <nav class="navbar navbar-expand-lg navbar-light">
-        <div class="container-fluid">
-          <div class="navbar-nav me-auto">
-            <h1><a class="nav-link navbar-brand" href="#">探求学園Rails専攻</a></h1>
-          </div>
-          <div>
-            <ul>
-              <p>〇〇 ××さん</p>
-            </ul>
-            <ul class="navbar-nav">
-              <a class="nav-link text-dark" href="#">商品検索</a>
-              <a class="nav-link text-dark" href="#">カート</a>
-              <a class="nav-link text-dark" href="#">注文履歴</a>
-              <a class="nav-link text-dark" href="#">ユーザ情報</a>
-              <a class="nav-link text-dark" href="#">ログアウト</a>
-            </ul>
+<main>
+  <% if @order.present? %>
+    <div class="mt-5 container">
+      <div class="jumbotron bg-white">
+        <div class="card border-dark">
+          <div class="cord-body ml-3">
+            <h4 class="mt-4">お届け先</h4>
+            <p class="ml-3"><%= "〒#{@order.user.zipcode[0..2]}-#{@order.user.zipcode[3..6]}#{@order.user.prefecture}#{@order.user.municipality}#{@order.user.address}#{@order.user.apartments}" %></p>
+            <p class="offset-sm-2"><%= "#{@order.user.last_name} #{@order.user.first_name}" %>様</p>
           </div>
         </div>
-      </nav>
-    </header>
-    <main>
-      <% if @order.present? %>
-        <div class="mt-5 container">
-          <div class="jumbotron bg-white">
-            <div class="card border-dark">
-              <div class="cord-body ml-3">
-                <h4 class="mt-4">お届け先</h4>
-                <p class="ml-3"><%= "〒#{@order.user.zipcode[0..2]}-#{@order.user.zipcode[3..6]}#{@order.user.prefecture}#{@order.user.municipality}#{@order.user.address}#{@order.user.apartments}" %></p>
-                <p class="offset-sm-2"><%= "#{@order.user.last_name} #{@order.user.first_name}" %>様</p>
-              </div>
-            </div>
-            <div class="mt-5 ml-3">
-              <p>注文番号：<%= @order.order_number %></p>
-              <p>注文状態：<%= @order.order_details.first.shipment_status.shipment_status_name %></p>
-              <div class="text-end">
-              <% if @order.has_prepared_shipment_status? %>
-                <%= link_to "注文をキャンセルする", "#", class: "btn btn-danger" %>
-              <% end %>
-              </div>
-            </div>
-            <table class="table table-borderless mt-3">
-              <thead>
-                <tr>
-                  <th scope="col" class="border-top border-bottom">No</th>
-                  <th scope="col" class="border-top border-bottom">商品名</th>
-                  <th scope="col" class="border-top border-bottom">商品カテゴリ</th>
-                  <th scope="col" class="border-top border-bottom">値段</th>
-                  <th scope="col" class="border-top border-bottom">個数</th>
-                  <th scope="col" class="border-top border-bottom">小計</th>
-                  <th scope="col" class="border-top border-bottom">備考</th>
-                </tr>
-              </thead>
-              <tbody>
-                <% @order.order_details.each do |order_detail| %>
-                <tr>
-                  <th scope="row">1</th>
-                  <td><%= order_detail.product.product_name %></td>
-                  <td><%= order_detail.product.category.category_name %></td>
-                  <td><%= order_detail.product.price %>円</td>
-                  <td><%= order_detail.order_quantity %>　個</td>
-                  <td><%= order_detail.sub_total_price %>円</td>
-                  <td>注文状態：<%= order_detail.shipment_status.shipment_status_name %></td>
-                </tr>
-                <% end %>
-              </tbody>
-            </table>
-            <div class="border-top border-dark">
-              <div class="mt-2 offset-sm-6">
-                <p class="ml-4">合計 <%= @order.products_total_fee %>円</p>
-              </div>
-            </div>
-            <div class="text-end mb-5">
-              <button type="button" class="btn btn-info">注文履歴に戻る</button>
-            </div>
+        <div class="mt-5 ml-3">
+          <p>注文番号：<%= @order.order_number %></p>
+          <p>注文状態：<%= @order.order_details.first.shipment_status.shipment_status_name %></p>
+          <div class="text-end">
+          <% if @order.has_prepared_shipment_status? %>
+            <%= link_to "注文をキャンセルする", "#", class: "btn btn-danger" %>
+          <% end %>
           </div>
         </div>
-      <% else %>
-        <div class="container">
-          <div class="jumbotron text-center bg-white"></div>
-          <div class="mt-5 text-center">
-            <h1>該当の注文は見つかりませんでした…</h1>
-            <p class="mt-5">注文履歴画面に戻り、やり直してください</p>
-            <button type="button" class="btn btn-primary">注文履歴へ</button>
+        <table class="table table-borderless mt-3">
+          <thead>
+            <tr>
+              <th scope="col" class="border-top border-bottom">No</th>
+              <th scope="col" class="border-top border-bottom">商品名</th>
+              <th scope="col" class="border-top border-bottom">商品カテゴリ</th>
+              <th scope="col" class="border-top border-bottom">値段</th>
+              <th scope="col" class="border-top border-bottom">個数</th>
+              <th scope="col" class="border-top border-bottom">小計</th>
+              <th scope="col" class="border-top border-bottom">備考</th>
+            </tr>
+          </thead>
+          <tbody>
+            <% @order.order_details.each do |order_detail| %>
+            <tr>
+              <th scope="row">1</th>
+              <td><%= order_detail.product.product_name %></td>
+              <td><%= order_detail.product.category.category_name %></td>
+              <td><%= order_detail.product.price %>円</td>
+              <td><%= order_detail.order_quantity %>　個</td>
+              <td><%= order_detail.sub_total_price %>円</td>
+              <td>注文状態：<%= order_detail.shipment_status.shipment_status_name %></td>
+            </tr>
+            <% end %>
+          </tbody>
+        </table>
+        <div class="border-top border-dark">
+          <div class="mt-2 offset-sm-6">
+            <p class="ml-4">合計 <%= @order.products_total_fee %>円</p>
           </div>
         </div>
+        <div class="text-end mb-5">
+          <button type="button" class="btn btn-info">注文履歴に戻る</button>
         </div>
-      <% end %>
-    </main>
-    <footer>
-      <h1>探求学園Rails専攻 </h1>
-      <p>© 2020 QuestAcademia, All rights reserved</p>
-    </footer>
-  </body>
-
-</html>
+      </div>
+    </div>
+  <% else %>
+    <div class="container">
+      <div class="jumbotron text-center bg-white"></div>
+      <div class="mt-5 text-center">
+        <h1>該当の注文は見つかりませんでした…</h1>
+        <p class="mt-5">注文履歴画面に戻り、やり直してください</p>
+        <button type="button" class="btn btn-primary">注文履歴へ</button>
+      </div>
+    </div>
+    </div>
+  <% end %>
+</main>


### PR DESCRIPTION
## このプルリクエストで何をしたのか
注文履歴画面の実装

## 対象issue
- https://github.com/quest-academia/qa-rails-ec-training-lily/issues/37

## 重点的に見てほしいところ(不安なところ)
- 注文履歴がなかった場合の表示は、画面定義所に従い「注文履歴が存在しません」としました。
mockupの「orders_index_not_found.html」の中身は「該当の注文は存在しません」となっており、
「orders_show_not_fount.html」の中身とほぼ同じになっていました。
- ユーザー詳細画面と同様、未ログイン時には「ログインしてください」、
他人の注文詳細を見ようとした場合には「他人の情報を見ることはできません」と表示するようにしました。
- 注文詳細画面（show.html.erb）のヘッダー・フッター対応も併せて行いました。

## 実装できなくて後回しにしたところ
なし

## チェックリスト
- [ ] 注文履歴画面の表示
- 「/orders」にアクセスした際に注文履歴一覧が表示される
- 注文履歴は15件ずつ表示される（ページネーション）
- 注文詳細に1件でも準備中の商品があれば「準備中」、なければ「発送済」と表示される
- 「詳細」ボタンを押下すると注文詳細画面に遷移する
- 注文履歴がなかった場合、「注文履歴が存在しません」と表示される
- [ ] 認可機構
- 未ログイン時に「/orders」「/orders/id」にアクセスした際は「ログインしてください」と表示されログイン画面にリダイレクト
- 他人の注文詳細画面にアクセスした際は「他人の情報を見ることはできません」と表示され注文履歴画面にリダイレクト
- [ ] ヘッダー
「注文履歴」を押下すると注文履歴画面に遷移
- [ ] rubocopは実行した？
- no offencesであることを確認

## その他参考情報
- 実装する上で参考にしたサイトなどがあればリンクをここに貼ること
