### PR TITLE
#38 注文キャンセル

### DIFF
--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -1,5 +1,5 @@
 class OrdersController < ApplicationController
-  before_action :logged_in_user, only: %i[show index]
+  before_action :logged_in_user, only: %i[show index destroy]
 
   def show
     @order = current_user.orders.find_by(id: params[:id])
@@ -7,5 +7,12 @@ class OrdersController < ApplicationController
 
   def index
     @orders = current_user.orders.order("order_date DESC").page(params[:page]).per(15)
+  end
+
+  def destroy
+    @order = Order.find_by(id: params[:id])
+    if @order.destroy!
+      redirect_to orders_path
+    end
   end
 end

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -10,9 +10,7 @@ class OrdersController < ApplicationController
   end
 
   def destroy
-    @order = Order.find_by(id: params[:id])
-    if @order.destroy!
-      redirect_to orders_path
-    end
+    @order = Order.find_by(id: params[:id]).destroy!
+    redirect_to orders_path
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -21,7 +21,7 @@ class UsersController < ApplicationController
       flash[:success] = "ユーザーを登録しました。こちらからログインしてください。"
       redirect_to login_path
     else
-      render 'new'
+      render "new"
     end
   end
 
@@ -49,9 +49,5 @@ class UsersController < ApplicationController
         flash[:danger] = "他人の情報にアクセスすることはできません。"
         redirect_to root_url
       end
-    end
-
-    def user_params
-      params.require(:user).permit(:last_name, :first_name, :zipcode, :prefecture, :municipality, :address, :apartments, :phone_number, :email, :password)
     end
 end

--- a/app/views/orders/show.html.erb
+++ b/app/views/orders/show.html.erb
@@ -14,7 +14,7 @@
           <p>注文状態：<%= @order.order_details.first.shipment_status.shipment_status_name %></p>
           <div class="text-end">
           <% if @order.has_prepared_shipment_status? %>
-            <%= link_to "注文をキャンセルする", "#", class: "btn btn-danger" %>
+            <%= link_to "注文をキャンセルする","#", method: :delete, class: "btn btn-danger" %>
           <% end %>
           </div>
         </div>


### PR DESCRIPTION
## このプルリクエストで何をしたのか
注文キャンセルボタンを押すとorder と order_detail が削除され注文履歴ページへリダイレクトするように設定しました。
## 対象issue
#38 注文キャンセル
- 作業したissueのURLをここに貼ること
https://github.com/quest-academia/qa-rails-ec-training-lily/compare/development...feature/%2338
## 重点的に見てほしいところ(不安なところ)
特にありません。
## 実装できなくて後回しにしたところ
特にありません。
## チェックリスト
- [ ✅] 動作確認は実行した?
- [ ✅] rubocopは実行した?

## その他参考情報
- 実装する上で参考にしたサイトなどがあればリンクをここに貼ること
https://qiita.com/shizen-shin/items/40b8426da34cc2d170c7