### PR TITLE
#39 カート機能

### DIFF
--- a/app/controllers/carts_controller.rb
+++ b/app/controllers/carts_controller.rb
@@ -1,0 +1,61 @@
+class CartsController < ApplicationController
+  def index
+    @cart = session[:cart].nil? ? [] : session[:cart]
+  end
+
+  def add_item
+    session[:cart] = [] if session[:cart].nil?
+
+    if index_of_added_item.nil?
+      session[:cart].push(added_item)
+    else
+      session[:cart][index_of_added_item]["quantity"] += params[:quantity].to_i
+    end
+
+    redirect_to carts_path
+  end
+
+  def change_quantity
+    session[:cart][index_of_added_item]["quantity"] = params[:quantity].to_i
+    redirect_to carts_path
+  end
+
+  def create
+    @order = Order.new(
+      order_date: Time.zone.now,
+      order_number: Order.last.order_number.to_i + 1,
+      user_id: current_user.id,
+    )
+    @order.save!
+
+    session[:cart].each.with_index(1) do |item, i|
+      @order_detail = OrderDetail.new(
+        order_detail_number: @order.order_number + "%05d" % i,
+        order_quantity: item["quantity"],
+        order_id: @order.id,
+        shipment_status_id: 1,
+        product_id: item["product_id"],
+      )
+      @order_detail.save!
+    end
+
+    session[:cart] = nil
+    redirect_to order_path(@order)
+  end
+
+  def destroy
+    session[:cart].delete_at(index_of_added_item)
+    redirect_to carts_path
+  end
+
+  private
+
+    def index_of_added_item
+      indexes = session[:cart].each_index.select {|i| session[:cart][i]["product_id"] == params[:product_id].to_i }
+      indexes[0]
+    end
+
+    def added_item
+      { product_id: params[:product_id].to_i, quantity: params[:quantity].to_i }
+    end
+end

--- a/app/controllers/carts_controller.rb
+++ b/app/controllers/carts_controller.rb
@@ -20,31 +20,6 @@ class CartsController < ApplicationController
     redirect_to carts_path
   end
 
-  # rubocop:disable Metrics::AbcSize
-  def create
-    @order = Order.new(
-      order_date: Time.zone.now,
-      order_number: Order.last.order_number.to_i + 1,
-      user_id: current_user.id,
-    )
-    @order.save!
-
-    session[:cart].each.with_index(1) do |item, i|
-      @order_detail = OrderDetail.new(
-        order_detail_number: @order.order_number + "%05d" % i,
-        order_quantity: item["quantity"],
-        order_id: @order.id,
-        shipment_status_id: 1,
-        product_id: item["product_id"],
-      )
-      @order_detail.save!
-    end
-
-    session[:cart] = nil
-    redirect_to order_path(@order)
-  end
-  # rubocop:enable Metrics::AbcSize
-
   def destroy
     session[:cart].delete_at(index_of_added_item)
     redirect_to carts_path

--- a/app/controllers/carts_controller.rb
+++ b/app/controllers/carts_controller.rb
@@ -1,6 +1,6 @@
 class CartsController < ApplicationController
   def index
-    @cart = session[:cart].nil? ? [] : session[:cart]
+    @cart = session[:cart] || []
   end
 
   def add_item

--- a/app/controllers/carts_controller.rb
+++ b/app/controllers/carts_controller.rb
@@ -20,6 +20,7 @@ class CartsController < ApplicationController
     redirect_to carts_path
   end
 
+  # rubocop:disable Metrics::AbcSize
   def create
     @order = Order.new(
       order_date: Time.zone.now,
@@ -42,6 +43,7 @@ class CartsController < ApplicationController
     session[:cart] = nil
     redirect_to order_path(@order)
   end
+  # rubocop:enable Metrics::AbcSize
 
   def destroy
     session[:cart].delete_at(index_of_added_item)

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -13,4 +13,29 @@ class OrdersController < ApplicationController
     @order = Order.find_by(id: params[:id]).destroy!
     redirect_to orders_path
   end
+
+  # rubocop:disable Metrics::AbcSize
+  def create
+    @order = Order.new(
+      order_date: Time.zone.now,
+      order_number: Order.last.order_number.to_i + 1,
+      user_id: current_user.id,
+    )
+    @order.save!
+
+    session[:cart].each.with_index(1) do |item, i|
+      @order_detail = OrderDetail.new(
+        order_detail_number: @order.order_number + "%05d" % i,
+        order_quantity: item["quantity"],
+        order_id: @order.id,
+        shipment_status_id: 1,
+        product_id: item["product_id"],
+      )
+      @order_detail.save!
+    end
+
+    session[:cart] = nil
+    redirect_to order_path(@order)
+  end
+  # rubocop:enable Metrics::AbcSize
 end

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -14,8 +14,7 @@ class OrdersController < ApplicationController
     redirect_to orders_path
   end
 
-  # rubocop:disable Metrics::AbcSize
-  def create
+  def create # rubocop:disable Metrics::AbcSize
     @order = Order.new(
       order_date: Time.zone.now,
       order_number: Order.last.order_number.to_i + 1,
@@ -37,5 +36,4 @@ class OrdersController < ApplicationController
     session[:cart] = nil
     redirect_to order_path(@order)
   end
-  # rubocop:enable Metrics::AbcSize
 end

--- a/app/helpers/carts_helper.rb
+++ b/app/helpers/carts_helper.rb
@@ -1,0 +1,25 @@
+module CartsHelper
+  def get_product_name(product_id)
+    Product.find_by(id: product_id).product_name
+  end
+
+  def get_category_name(product_id)
+    Product.find_by(id: product_id).category.category_name
+  end
+
+  def get_price(product_id)
+    Product.find_by(id: product_id).price
+  end
+
+  def get_sub_total(item)
+    get_price(item["product_id"]) * item["quantity"]
+  end
+
+  def get_total(cart)
+    total = 0
+    cart.each do |item|
+      total += get_sub_total(item)
+    end
+    total
+  end
+end

--- a/app/helpers/carts_helper.rb
+++ b/app/helpers/carts_helper.rb
@@ -16,10 +16,6 @@ module CartsHelper
   end
 
   def get_total(cart)
-    total = 0
-    cart.each do |item|
-      total += get_sub_total(item)
-    end
-    total
+    cart.sum {get_sub_total(_1)}
   end
 end

--- a/app/helpers/sessions_helper.rb
+++ b/app/helpers/sessions_helper.rb
@@ -5,6 +5,7 @@ module SessionsHelper
 
   def log_out
     session.delete(:user_id)
+    session[:cart] = nil
   end
 
   def logged_in?

--- a/app/views/carts/index.html.erb
+++ b/app/views/carts/index.html.erb
@@ -100,7 +100,7 @@
               <td class="border-0">
               </td>
               <td class="border-0">
-                <%= button_to "注文を確定する", carts_path , method: :post ,class:"btn btn-primary"%>
+                <%= button_to "注文を確定する", orders_path , method: :post ,class:"btn btn-primary"%>
               </td>
               <td class="border-0 align-middle">
               </td>

--- a/app/views/carts/index.html.erb
+++ b/app/views/carts/index.html.erb
@@ -60,7 +60,7 @@
                 </td>
                 <td class="align-middle">
                   <%= form_with(url: change_quantity_path, local: true) do |f| %>
-                    <%= f.text_field :product_id, value:item["product_id"], hidden:true %>
+                    <%= hidden_field_tag :product_id, item["product_id"] %>
                     <%= f.number_field :quantity, value:item["quantity"], min: 1, max:999, required:true %>&nbsp;&nbsp;個
                     <%= f.submit "更新", class: 'btn btn-light' %>
                   <% end %>

--- a/app/views/carts/index.html.erb
+++ b/app/views/carts/index.html.erb
@@ -61,7 +61,7 @@
                 <td class="align-middle">
                   <%= form_with(url: change_quantity_path, local: true) do |f| %>
                     <%= f.text_field :product_id, value:item["product_id"], hidden:true %>
-                    <%= f.text_field :quantity, value:item["quantity"], pattern:"[1-9][0-9]*", min:"1", required:true, size:"2" %>&nbsp;&nbsp;個
+                    <%= f.number_field :quantity, value:item["quantity"], min: 1, max:999, required:true %>&nbsp;&nbsp;個
                     <%= f.submit "更新", class: 'btn btn-light' %>
                   <% end %>
                 </td>

--- a/app/views/carts/index.html.erb
+++ b/app/views/carts/index.html.erb
@@ -1,0 +1,122 @@
+<main>
+
+  <% if @cart.present? %>
+    <div class="container">
+      <div class="row">
+        <div class="col-12 card border-dark mt-5">
+          <div class="cord-body ml-3 mb-2">
+            <h4 class="mt-4">お届け先</h4>
+            <p class="mb-2" style="padding-left: 20px;">
+              <%= "〒#{current_user.zipcode[0..2]}-#{current_user.zipcode[3..6]}" %>
+              <%= "#{current_user.prefecture}#{current_user.municipality}#{current_user.address}#{current_user.apartments}" %>
+            </p>
+            <p style="padding-left: 160px;">
+              <%= "#{current_user.last_name} #{current_user.first_name}様"%>
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="container">
+      <div class="row">
+        <table class="table mt-5 ml-3 border-dark">
+          <thead>
+            <tr class="text-center">
+              <th class="border-bottom border-dark" style="width:13%;">
+                No
+              </th>
+              <th class="border-bottom border-dark" style="width:18%;">
+                商品名
+              </th>
+              <th class="border-bottom border-dark" style="width:15%;">
+                商品カテゴリ
+              </th>
+              <th class="border-bottom border-dark" style="width:15%;">
+                値段
+              </th>
+              <th class="border-bottom border-dark" style="width:15%;">
+                個数
+              </th>
+              <th class="border-bottom border-dark" style="width:15%;">
+                小計
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            <% @cart.each.with_index(1) do |item,i| %>
+              <tr class="text-center">
+                <th class="align-middle">
+                  <%= i %>
+                </th>
+                <td class="align-middle">
+                  <%= get_product_name(item["product_id"]) %>
+                </td>
+                <td class="align-middle">
+                  <%= get_category_name(item["product_id"]) %>
+                </td>
+                <td class="align-middle">
+                  <%= "#{get_price(item["product_id"])}円" %>
+                </td>
+                <td class="align-middle">
+                  <%= form_with(url: change_quantity_path, local: true) do |f| %>
+                    <%= f.text_field :product_id, value:item["product_id"], hidden:true %>
+                    <%= f.text_field :quantity, value:item["quantity"], pattern:"[1-9][0-9]*", min:"1", required:true, size:"2" %>&nbsp;&nbsp;個
+                    <%= f.submit "更新", class: 'btn btn-light' %>
+                  <% end %>
+                </td>
+                <td class="align-middle">
+                  <%= "#{get_sub_total(item)}円" %>
+                </td>
+                <td class="border-0 align-middle">
+                  <%= link_to "削除", delete_item_path(item) ,  method: :delete, class:"btn btn-danger"%>
+                </td>
+              </tr>
+            <% end %>
+            <tr class="text-center">
+              <th class="border-bottom-0 align-middle">
+              </th>
+              <td class="border-bottom-0 align-middle">
+              </td>
+              <td class="border-bottom-0 align-middle">
+              </td>
+              <td class="border-bottom-0 align-middle">
+              </td>
+              <td class="border-bottom-0 align-middle">
+                合計
+              </td>
+              <td class="border-bottom-0 align-middle">
+                <%= "#{get_total(@cart)}円" %>
+              </td>
+            </tr>
+            <tr class="text-right">
+              <th class="border-0">
+              </th>
+              <td class="border-0">
+                <%= button_to "買い物を続ける", products_path , method: :get, class:"btn btn-success"%>
+              </td>
+              <td class="border-0">
+              </td>
+              <td class="border-0">
+              </td>
+              <td class="border-0">
+                <%= button_to "注文を確定する", carts_path , method: :post ,class:"btn btn-primary"%>
+              </td>
+              <td class="border-0 align-middle">
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+
+  <% else %>
+
+    <div class="blockquote mt-5 text-center">
+      <h1 style="font-weight: bolder">カートに商品はありません</h1>
+    </div>
+
+  <% end %>
+
+
+</main>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -12,7 +12,7 @@
          </ul>
           <ul class="navbar-nav">
             <%= link_to "商品検索", products_path ,class:"nav-link text-dark"%>
-            <a class="nav-link text-dark" href="#">カート</a>
+            <%= link_to "カート", carts_path ,class:"nav-link text-dark"%>
             <%= link_to "注文履歴", orders_path ,class:"nav-link text-dark"%>
             <%= link_to "ユーザ情報", user_path(@current_user) ,class:"nav-link text-dark"%>
             <%= link_to "ログアウト", logout_path , method: :delete ,class:"nav-link text-dark"%>

--- a/app/views/products/show.html.erb
+++ b/app/views/products/show.html.erb
@@ -10,16 +10,25 @@
             <p>探求学園Rails専攻限定商品！</p>
             <p class="mt-4 mb-5"><%= @product.price %></p>
           </div>
-          <div class="row justify-content-center">
-            <label for="order_quanity" class="mt-1 col-sm-1">購入個数</label>
-            <div class="col-sm-1">
-              <input required type="text" class="form-control" id="order_quanity" pattern="[1-9][0-9]*" min="1">
+
+          <%= form_with(url: add_item_path, local: true) do |f| %>
+
+            <div class="row justify-content-center">
+              <%= f.label :購入個数, class:'mt-1 col-sm-1' %>
+              <div class="col-sm-1">
+                <%= f.text_field :quantity ,class:'form-control', pattern: "[1-9][0-9]*" ,min: "1",required:true %>
+              </div>
+              <%= f.label :個, class:'mt-1 col-sm-1' %>
+
+              <%= f.text_field :product_id ,value:@product.id  ,hidden:true %>
+
+              <div class="col-sm-2">
+                <%= f.submit "カートへ", class: 'btn btn-primary btn-block' %>
+              </div>
             </div>
-            <label class="mt-1 col-sm-1">個</label>
-            <div class="col-sm-2">
-              <button type="button" class="btn btn-primary btn-block">カートへ</button>
-            </div>
-          </div>
+
+          <% end %>
+
         </div>
       </div>
     <% else %>

--- a/app/views/products/show.html.erb
+++ b/app/views/products/show.html.erb
@@ -16,7 +16,7 @@
             <div class="row justify-content-center">
               <%= f.label :購入個数, class:'mt-1 col-sm-1' %>
               <div class="col-sm-1">
-                <%= f.text_field :quantity ,class:'form-control', pattern: "[1-9][0-9]*" ,min: "1",required:true %>
+                <%= f.number_field :quantity, class:'form-control',  min: 1, max:999, required:true %>
               </div>
               <%= f.label :個, class:'mt-1 col-sm-1' %>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,7 +5,11 @@ Rails.application.routes.draw do
   delete    '/logout', to: 'sessions#destroy'
   get       '/signup', to: 'users#new'
   post      '/signup', to: 'users#create'
+  post      '/add_item',        to: 'carts#add_item'
+  post      '/change_quantity', to: 'carts#change_quantity'
+  delete    '/delete_item',     to: 'carts#destroy'
   resources :products
   resources :users
   resources :orders
+  resources :carts
 end


### PR DESCRIPTION
## このプルリクエストで何をしたのか
カート機能の実装

## 対象issue
- https://github.com/quest-academia/qa-rails-ec-training-lily/issues/39

## 重点的に見てほしいところ(不安なところ)
- CartsControllerでsession[:cart]からproduct_id、quantityを取り出す際、
シンボルで取り出せなかったためテキストのキー指定（"product_id"、"quantity"）で取得しました。
セットするときはシンボルにしているのですが、その後テキストのキー指定に変わってしまうようでした。
- カートの数量変更で、数量と変更ボタンのみをform_withで囲み、change_quantityアクションと紐づけました。

## 実装できなくて後回しにしたところ
- rubocop指摘の対応
Cart#createメソッドでAbcSizeエラー
メソッドの分割を行えば解消しそうだが、どう分割すべきか悩んだため一旦このまま提出しました。
日本語の文献の多くはAbcSizeチェックの設定変更で対応していました。
https://www.rubydoc.info/gems/rubocop/0.27.0/RuboCop/Cop/Metrics/AbcSize
https://qiita.com/kumashun/items/483fd7d73256c786d724


## チェックリスト
- [x] 動作確認：カート一覧画面
- /carts へのアクセスでカート一覧画面へ遷移
- ヘッダの「カート」の押下でカート一覧画面へ遷移
- カートの中身がない場合、「カートに商品はありません」と表示
- 合計は、小径の合算と一致
- カートの商品の商品名、カテゴリ、金額、数量、小計が選択した通りに表示されている
- 数量変更後、「更新」を押すと小計、合計が更新される
- 「注文を確定する」を押すと注文履歴が作成される
- 「買い物を続ける」を押すと商品検索画面へ遷移する

- [x] 動作確認：商品追加
- 商品詳細画面から数量を入力し、「カートへ」を押すと、該当商品・個数がカートへ反映される
- カートへ登録ずみの商品を追加した場合、該当商品のカート内の数量が加算される

- [x] 動作確認：削除
- カート画面で「削除」を押すと、該当の商品がカートから削除され、合計が再計算される

- [x] 動作確認：ログアウト
- ログアウトするとカート内商品がクリアされる

- [x] rubocopは実行した?
- 実行済み。上記の通りAbcSizeチェックのみ未対応。

## その他参考情報
- RuboCopのAbcSizeチェックの対応　https://qiita.com/kumashun/items/483fd7d73256c786d724
- Ruby 配列のselect でwith_indexを利用　https://qiita.com/vsanna/items/6dd7247ad8f7dd81fe03
